### PR TITLE
Fix errors with quickly deleted files

### DIFF
--- a/lib/notes-store.js
+++ b/lib/notes-store.js
@@ -59,7 +59,7 @@ function createDocument (filePath) {
       keywords: keywords,
       abstract: abstract
     }
-  } catch(_) {
+  } catch (_) {
     return {}
   }
 }

--- a/lib/notes-store.js
+++ b/lib/notes-store.js
@@ -26,6 +26,7 @@ const {watchPath} = require('atom')
  * @return {DocumentItem}
  */
 function createDocument (filePath) {
+  if (!fs.existsSync(filePath)) { return false }
   let fileStats = fs.statSync(filePath)
   let fileName = path.basename(filePath)
   let title = path.basename(fileName, path.extname(fileName))
@@ -48,14 +49,18 @@ function createDocument (filePath) {
     abstract = meta.abstract
   }
 
-  return {
-    filePath: filePath,
-    fileName: fileName,
-    title: title,
-    modifiedAt: fileStats.mtime,
-    body: body,
-    keywords: keywords,
-    abstract: abstract
+  try {
+    return {
+      filePath: filePath,
+      fileName: fileName,
+      title: title,
+      modifiedAt: fileStats.mtime,
+      body: body,
+      keywords: keywords,
+      abstract: abstract
+    }
+  } catch(_) {
+    return {}
   }
 }
 
@@ -164,6 +169,7 @@ class NotesStore extends EventEmitter {
    * @param {DocumentItem} doc
    */
   removeDocument (doc) {
+    if (doc === undefined) { return false }
     delete this._documents[doc.filePath]
     let data = {
       id: doc.filePath,


### PR DESCRIPTION
## Details:

My wife and I were both (on separate macs) getting the same errors. This pull request fixes those as far as I can tell. I'm not sure about the state of the specs so I didn't write a new one for this.

On the error - as far as I could tell, when I would create a new document in Typora and saved in the notes directory, then quickly saved again I would see errors because a file wasn't there anymore. I think Typora must save a temp file as the file name plus a tilde. That tilde filename was what was throwing the error. 

😃 
