### PR TITLE
Create URI scheme to toggle notes view from outside Atom #31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /npm-debug.log
 /node_modules
 /package-lock.json
-
+.tags*

--- a/README.md
+++ b/README.md
@@ -90,17 +90,21 @@ above.
 
 ## Triggering from outside Atom
 
-To add Atom Notes to the Apple Services menu use this [Apple service][apple-service].
+To add Atom Notes to the Apple Services menu and set a keyboard shortcut for use
+outside Atom use this [Apple service][apple-service]. Then use your configured
+shortcut &mdash; see the section on Keybindings, above, for details on
+configuring a shortcut inside Atom &mdash; from inside or outside Atom to toggle
+the notes view.
 
-Otherwise in macOS and Windows the URL `atom://atom-notes/toggle` will toggle the notes view.
-The command will operate in the front-most or most recently active window or open a new one. It will
-start Atom if necessary. There are many ways to automate this. For example, in macOS:
+Alternatively in macOS and Windows the URL `atom://atom-notes/toggle` will
+toggle the notes view. The command will operate in the front-most or most
+recently active window or open a new one. It will start Atom if necessary. There
+are many ways to automate this. For example, in macOS:
 
 - Call `open atom://atom-notes/toggle` from the command line or a script.
 - Use the [Apple service][apple-service] mentioned above.
 - Install [Alfred][alfred] (requires the Power Pack purchase) and the
-[alfred-atom-notes workflow][alfred-atom-notes]. Then use the configurable
-shortcut, shift-cmd-j, from inside or outside Atom to toggle the notes view.
+[alfred-atom-notes workflow][alfred-atom-notes].
 
 ## ⚠️ Incompatible Package Error
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ editor.
 - Mouseless Interaction
 - Incremental Search
 - Interlinks
+- Triggerable from outside Atom
 
 > **Note:** For interlink syntax highlighting, please install
 >           [`language-atom-notes`][language-atom-notes].
@@ -86,6 +87,13 @@ above.
 - `atom-notes:toggle`: Toggle the search box.
 - `atom-notes:interlink`: Jumps to referred note when the cursor is on
   an `[[interlink]]`.
+
+## Triggering from outside Atom
+
+To toggle the notes view from outside Atom use the URL `atom://atom-notes/toggle`. Atom supports URL schemes only from macOS or Windows. This URL command will operate in the front-most, most recently active, or a new Atom window. It will start Atom if necessary. For example, from macOS:
+
+- Call `open atom://atom-notes/toggle` from bash.
+- Install [Alfred](alfred) (requires the Power Pack purchase) and the [alfred-atom-notes workflow](alfred-atom-notes). Then use the configurable shortcut, shift-cmd-j, from inside or outside Atom to toggle the notes view.
 
 ## ⚠️ Incompatible Package Error
 
@@ -201,5 +209,7 @@ specification. Contributions of any kind welcome!
 [nv]:                   http://notational.net/
 [nvalt]:                http://brettterpstra.com/projects/nvalt/
 [nvatom]:               https://github.com/seongjaelee/nvatom
+[alfed]:                http://www.alfredapp.com
+[alfred-atom-notes]:    https://github.com/robwalton/alfred-atom-notes
 [screencast]:           https://user-images.githubusercontent.com/1903876/28757512-67bb005c-754a-11e7-99bd-5babb98ac056.gif
 [use-search-index]:     https://github.com/seongjaelee/nvatom/issues/35#issuecomment-143653832

--- a/lib/atom-notes.js
+++ b/lib/atom-notes.js
@@ -18,6 +18,7 @@ export default {
    * @param {SerializedIndex} state A previously serialized document storage index to load.
    */
   activate (state) {
+    console.info("Activating atom-notes")
     this.store = null
     this.ready = undefined
     this.doSerialize = true
@@ -26,6 +27,25 @@ export default {
       makeReady(this, state)
     } else {
       makeReady(this)
+    }
+  },
+
+  /**
+  * Handle URI calls to `atom://atom-notes`. See:
+  * <https://flight-manual.atom.io/hacking-atom/sections/handling-uris/>
+  *
+  * Specifically `atom://atom-notes/toggle` will toggle the atom-notes view in
+  * the front-most, most recently active or a new, Atom window; will start
+  * atom if necessary.
+  *
+  * @param {urlObject} parsedUri URI parsed with Node's url.parse(uri, true)
+  */
+  handleURI (parsedUri) {
+    if (parsedUri.pathname === '/toggle') {
+      this.getNotesView().toggle()
+    } else {
+      atom.notifications.addError(
+        'Only the URI `atom://atom-notes/toggle` is currently supported')
     }
   },
 
@@ -43,7 +63,7 @@ export default {
       try {
         data = JSON.stringify(this.store.index)
       } catch (e) {
-        console.error('atom-notes: serilization failutre', e)
+        console.error('atom-notes: serilization failure', e)
       }
       const maxSerializedDataLength = 133169152
       if (data && data.length < maxSerializedDataLength) {

--- a/lib/atom-notes.js
+++ b/lib/atom-notes.js
@@ -18,7 +18,7 @@ export default {
    * @param {SerializedIndex} state A previously serialized document storage index to load.
    */
   activate (state) {
-    console.info("Activating atom-notes")
+    console.info('Activating atom-notes')
     this.store = null
     this.ready = undefined
     this.doSerialize = true
@@ -63,7 +63,7 @@ export default {
       try {
         data = JSON.stringify(this.store.index)
       } catch (e) {
-        console.error('atom-notes: serilization failure', e)
+        console.error('atom-notes: serialization failure', e)
       }
       const maxSerializedDataLength = 133169152
       if (data && data.length < maxSerializedDataLength) {

--- a/lib/notes-store.js
+++ b/lib/notes-store.js
@@ -4,6 +4,7 @@ import elasticlunr from 'elasticlunr'
 import fs from 'fs-plus'
 import path from 'path'
 import matter from 'gray-matter'
+import * as NotesFs from './notes-fs'
 
 let {EventEmitter} = require('events')
 const {watchPath} = require('atom')
@@ -68,7 +69,9 @@ async function setupFileWatcher (directoryPath) {
   const watchedDirectory = fs.normalize(directoryPath)
   fs.listTreeSync(watchedDirectory).forEach(path => {
     if (!fs.isDirectorySync(path)) {
-      this.addDocument(createDocument(path))
+      if (NotesFs.isNote(path)) {
+        this.addDocument(createDocument(path))
+      }
     }
   })
   return watchPath(watchedDirectory, {}, events => {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
   "deserializers": {
     "SearchIndex": "deserializeSearchIndex"
   },
+  "uriHandler": {
+    "method": "handleURI",
+    "deferActivation": false
+  },
   "dependencies": {
     "elasticlunr": "^0.9.5",
     "etch": "^0.12.6",


### PR DESCRIPTION
I think this should just work. I've added documentation to the README file including links to add a command to the apple Services menu and to apple's Alfred app. No need for the latter with the former, but I'd already made it before I realised! And who knows --- it might turn into something better later.