### PR TITLE
Added support for markdown-preview-plus.

### DIFF
--- a/lib/atom-notes.js
+++ b/lib/atom-notes.js
@@ -44,10 +44,15 @@ export default {
     if (parsedUri.pathname === '/toggle') {
       this.getNotesView().toggle()
     } if (parsedUri.pathname === '/toggle/preview') {
-      this.getNotesView().toggle(true)
+      if (this.markdownUri) {
+        this.getNotesView().toggle(this.markdownUri)
+      } else {
+        atom.notifications.addError(
+          'markdown-preview or markdown-preview-plus is required for this uri to work')
+      }
     } else {
       atom.notifications.addError(
-        'Only the URI `atom://atom-notes/toggle` is currently supported')
+        'Only the URI `atom://atom-notes/toggle` and `atom:///atom-notes/toggle/preview` is currently supported')
     }
   },
 
@@ -183,13 +188,78 @@ function handleEvents (self) {
   const {openInterlink} = require('./interlink')
   const {CompositeDisposable, Disposable} = require('atom')
   self.subs = new CompositeDisposable()
-
+  
+  /**
+   * List of supported preview packages in order from the most important.
+   */
+  let markdownPreviewPackages = {
+    'markdown-preview-plus': 'markdown-preview-plus://file/',
+    'markdown-preview': 'markdown-preview://',
+  }
+  let previewCommand = null
+  
   // user commands
   self.subs.add(
     atom.commands.add('atom-workspace', 'atom-notes:toggle', () => self.getNotesView().toggle()),
-    atom.commands.add('atom-workspace', 'atom-notes:toggle-preview', () => self.getNotesView().toggle(true)),
     atom.commands.add('atom-workspace', 'atom-notes:interlink', () => openInterlink())
   )
+  
+  /**
+   * Quickly activate the 'atom-notes:toggle-preview' command if not
+   * already active.
+   */
+  function activatePreviewCommand() {
+    if (!previewCommand) {
+      previewCommand = atom.commands.add(
+        'atom-workspace',
+        'atom-notes:toggle-preview',
+        () => self.getNotesView().toggle(self.markdownUri))
+      self.subs.add(previewCommand)
+    }
+  }
+  
+  /**
+   * Quickly deactivate the 'atom-notes:toggle-preview' command if is
+   * already active.
+   */
+  function deactivatePreviewCommand() {
+    if (previewCommand) {
+      if (self.subs) {
+        self.subs.remove(previewCommand)
+      }
+      previewCommand.dispose()
+      previewCommand = null
+    }
+  }
+  
+  /**
+   * Choose first active package from markdownPreviewPackages, set the uri
+   * and activate the command if not already active. If none of the packages
+   * from the list is active it will deactivate the command and reset the uri.
+   */
+  function activatePreview() {
+    for ([package, uri] of Object.entries(markdownPreviewPackages)) {
+      if (atom.packages.isPackageActive(package)) {
+        self.markdownUri = uri
+        activatePreviewCommand()
+        return
+      }
+    }
+    deactivatePreviewCommand()
+    self.markdownUri = null
+  }
+  
+  /**
+   * Let's initialize on start
+   */
+  activatePreview()
+  
+  /**
+   * Check the packages again if something changed and activate or deactivate
+   * the command and uri.
+   */
+  atom.packages.onDidActivatePackage(activatePreview)
+  atom.packages.onDidDeactivatePackage(activatePreview)
 
   // window::beforeunload
   window.addEventListener('beforeunload', autosaveAll, true)
@@ -304,9 +374,11 @@ async function autodelete (paneItem) {
  */
 function autosaveAll () {
   if (!atom.config.get('atom-notes.enableAutosave')) return
-  __guard__(atom.workspace.getPaneItems(), items => {
-    items.forEach(i => autosave(i))
-  })
+  if (atom.workspace) {
+    __guard__(atom.workspace.getPaneItems(), items => {
+      items.forEach(i => autosave(i))
+    })
+  }
 }
 
 function __guard__ (value, transform) {

--- a/lib/notes-view-list.js
+++ b/lib/notes-view-list.js
@@ -24,7 +24,7 @@ let autocompleteTimeout
   * @typedef Options
   * @type {Object}
   * @property {function()} [didHide] - Callback to call whenever this view is hidden.
-  * @property {Boolean} [preview] - Set to true if document should open in markdown preview
+  * @property {String} [markdownUri] - Null or uri prefix for markdown-preview
   */
 
 export default class NotesViewList {
@@ -233,8 +233,8 @@ export default class NotesViewList {
    */
   didConfirmSelection (item) {
     this.didHide()
-    if (this.openInPreview) {
-      atom.workspace.open(`markdown-preview://${encodeURI(item.filePath)}`)
+    if (this.markdownUri) {
+      atom.workspace.open(`${this.markdownUri}${encodeURI(item.filePath)}`)
     } else {
       atom.workspace.open(item.filePath)
     }

--- a/lib/notes-view.js
+++ b/lib/notes-view.js
@@ -28,15 +28,15 @@ export default class NotesView {
 
   /**
    * Brings up the notes view so the user can see it.
-   * @param {Boolean} preview Whether to open file in editor or preview.
+   * @param {String} markdownUri Null or uri prefix for markdown-preview
    */
-  show (preview) {
+  show (markdownUri) {
     this.previousFocus = document.activeElement
     this.list.selectListView.selectNone()
     this.list.autocomplete()
     this.panel.show()
     this.list.selectListView.focus()
-    this.list.openInPreview = preview
+    this.list.markdownUri = markdownUri
   }
 
   /**
@@ -48,10 +48,10 @@ export default class NotesView {
 
   /**
    * Toggles between hidden and shown.
-   * @param {Boolean} preview Whether to open file in editor or preview.
+   * @param {String} markdownUri Null or uri prefix for markdown-preview
    */
-  toggle (preview) {
-    this.isVisible() ? this.hide() : this.show(preview)
+  toggle (markdownUri) {
+    this.isVisible() ? this.hide() : this.show(markdownUri)
   }
 
   destroy () {


### PR DESCRIPTION
- Improved the code (I think)
- Added support for ```markdown-preview-plus```.
- Only add the command if at least one of ```markdown-preview``` or ```markdown-preview-plus``` is active.
- Dynamically disable/activate command when disabling/enabling packages.